### PR TITLE
fix: Rename nullbr_app_id to nullbr_appid to avoid legacy config loading

### DIFF
--- a/plugins.v2/p115strgmsub/__init__.py
+++ b/plugins.v2/p115strgmsub/__init__.py
@@ -77,7 +77,7 @@ class P115StrgmSub(_PluginBase):
     _only_115: bool = True  # 只搜索115网盘资源
     _exclude_subscribes: List[int] = []  # 排除的订阅ID列表
     _nullbr_enabled: bool = False  # 是否启用 Nullbr 查询
-    _nullbr_app_id: str = ""  # Nullbr APP ID
+    _nullbr_appid: str = ""  # Nullbr APP ID（新字段名，避免加载旧配置）
     _nullbr_api_key: str = ""  # Nullbr API Key
     _nullbr_priority: bool = True  # Nullbr 优先（True: 优先使用 Nullbr，False: 优先使用 PanSou）
     _block_system_subscribe: bool = False  # 是否屏蔽系统订阅
@@ -109,7 +109,7 @@ class P115StrgmSub(_PluginBase):
             self._only_115 = config.get("only_115", True)
             self._exclude_subscribes = config.get("exclude_subscribes", []) or []
             self._nullbr_enabled = config.get("nullbr_enabled", False)
-            self._nullbr_app_id = config.get("nullbr_app_id", "")
+            self._nullbr_appid = config.get("nullbr_appid", "")
             self._nullbr_api_key = config.get("nullbr_api_key", "")
             self._nullbr_priority = config.get("nullbr_priority", True)
             
@@ -159,16 +159,16 @@ class P115StrgmSub(_PluginBase):
 
         # 初始化 Nullbr 客户端
         if self._nullbr_enabled:
-            if not self._nullbr_app_id or not self._nullbr_api_key:
+            if not self._nullbr_appid or not self._nullbr_api_key:
                 missing = []
-                if not self._nullbr_app_id:
+                if not self._nullbr_appid:
                     missing.append("APP ID")
                 if not self._nullbr_api_key:
                     missing.append("API Key")
                 logger.warning(f"⚠️ Nullbr 已启用但缺少必要配置：{', '.join(missing)}，将无法使用 Nullbr 查询功能")
                 self._nullbr_client = None
             else:
-                self._nullbr_client = NullbrClient(app_id=self._nullbr_app_id, api_key=self._nullbr_api_key)
+                self._nullbr_client = NullbrClient(app_id=self._nullbr_appid, api_key=self._nullbr_api_key)
                 logger.info("✓ Nullbr 客户端初始化成功")
 
     def get_state(self) -> bool:
@@ -267,7 +267,7 @@ class P115StrgmSub(_PluginBase):
             "pansou_auth_enabled": self._pansou_auth_enabled,
             "pansou_channels": self._pansou_channels,
             "nullbr_enabled": self._nullbr_enabled,
-            "nullbr_app_id": self._nullbr_app_id,
+            "nullbr_appid": self._nullbr_appid,
             "nullbr_api_key": self._nullbr_api_key,
             "nullbr_priority": self._nullbr_priority,
             "exclude_subscribes": self._exclude_subscribes,

--- a/plugins.v2/p115strgmsub/ui_config.py
+++ b/plugins.v2/p115strgmsub/ui_config.py
@@ -137,7 +137,7 @@ class UIConfig:
                         'content': [
                             {'component': 'VCol', 'props': {'cols': 6, 'md': 3}, 'content': [{'component': 'VSwitch', 'props': {'model': 'nullbr_enabled', 'label': '启用 Nullbr'}}]},
                             {'component': 'VCol', 'props': {'cols': 6, 'md': 3}, 'content': [{'component': 'VSwitch', 'props': {'model': 'nullbr_priority', 'label': 'Nullbr 优先'}}]},
-                            {'component': 'VCol', 'props': {'cols': 12, 'md': 3}, 'content': [{'component': 'VTextField', 'props': {'model': 'nullbr_app_id', 'label': 'Nullbr APP ID', 'placeholder': '请输入 APP ID'}}]},
+                            {'component': 'VCol', 'props': {'cols': 12, 'md': 3}, 'content': [{'component': 'VTextField', 'props': {'model': 'nullbr_appid', 'label': 'Nullbr APP ID', 'placeholder': '请输入 APP ID'}}]},
                             {'component': 'VCol', 'props': {'cols': 12, 'md': 3}, 'content': [{'component': 'VTextField', 'props': {'model': 'nullbr_api_key', 'label': 'Nullbr API Key', 'type': 'password', 'placeholder': '请输入 API Key'}}]}
                         ]
                     },
@@ -170,7 +170,7 @@ class UIConfig:
             "pansou_auth_enabled": False,
             "pansou_channels": "QukanMovie",
             "nullbr_enabled": False,
-            "nullbr_app_id": "",
+            "nullbr_appid": "",
             "nullbr_api_key": "",
             "nullbr_priority": True,
             "exclude_subscribes": [],


### PR DESCRIPTION
Changed field name from 'nullbr_app_id' to 'nullbr_appid' to prevent existing users from loading the old hardcoded default APP ID value.

**Why this change is needed:**
When we changed the default APP ID from "J5LrECLuR" to empty string, existing users who already saved their config would still have the old APP ID value stored. Even though we removed the default, config.get() would return the previously saved value.

**Solution:**
By renaming the field, old configs will not match and the new field will default to empty string, forcing users to reconfigure if they want to use Nullbr.

**Changes:**
- Renamed _nullbr_app_id -> _nullbr_appid in all locations
- Updated config loading, saving, and UI form
- Updated NullbrClient initialization call

This ensures a clean break from the old default value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Nullbr APP ID configuration field naming from `nullbr_app_id` to `nullbr_appid` across plugin configuration, state serialization, and the UI configuration form.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->