### PR TITLE
fix(p115strgmsub): 添加 PanSou 搜索结果精确过滤

### DIFF
--- a/plugins.v2/p115strgmsub/handlers/search.py
+++ b/plugins.v2/p115strgmsub/handlers/search.py
@@ -182,6 +182,15 @@ class SearchHandler:
 
         results = search_results.get("results", {}) if search_results and not search_results.get("error") else {}
         return results.get("115网盘", [])
+    def _normalize(self, text: str) -> str:
+        """
+        归一化文本：移除所有非字母数字字符，只保留字母和数字
+
+        :param text: 待处理文本
+        :return: 归一化后的文本
+        """
+        return "".join(ch for ch in (text or "").lower() if ch.isalnum())
+
     def _filter_pansou_results_by_title(
         self,
         results: List[Dict],
@@ -201,17 +210,19 @@ class SearchHandler:
         if not results or not mediainfo:
             return results
 
+        # 归一化目标标题
+        normalized_title = self._normalize(mediainfo.title)
+
         filtered = []
         for result in results:
             title = result.get("title", "") or result.get("name", "") or ""
             url = result.get("url", "") or ""
 
-            # 合并标题和 URL 进行检查
-            combined_text = f"{title} {url}".lower()
+            # 合并标题和 URL 进行检查（归一化后匹配）
+            combined_text = self._normalize(f"{title} {url}")
 
-            # 检查标题是否包含媒体标题的关键字（移除空格后匹配）
-            title_keywords = mediainfo.title.lower().replace(" ", "")
-            if title_keywords not in combined_text.replace(" ", ""):
+            # 检查标题是否包含媒体标题的关键字（归一化后匹配）
+            if normalized_title not in combined_text:
                 logger.debug(f"PanSou 结果标题不匹配: {title} (期望: {mediainfo.title})，跳过")
                 continue
 

--- a/plugins.v2/p115strgmsub/handlers/search.py
+++ b/plugins.v2/p115strgmsub/handlers/search.py
@@ -182,6 +182,68 @@ class SearchHandler:
 
         results = search_results.get("results", {}) if search_results and not search_results.get("error") else {}
         return results.get("115网盘", [])
+    def _filter_pansou_results_by_title(
+        self,
+        results: List[Dict],
+        mediainfo: MediaInfo,
+        media_type: MediaType,
+        season: Optional[int] = None
+    ) -> List[Dict]:
+        """
+        过滤 PanSou 搜索结果，确保标题、年份、季号匹配
+
+        :param results: PanSou 搜索结果
+        :param mediainfo: 媒体信息
+        :param media_type: 媒体类型
+        :param season: 季号（电视剧）
+        :return: 过滤后的结果
+        """
+        if not results or not mediainfo:
+            return results
+
+        filtered = []
+        for result in results:
+            title = result.get("title", "") or result.get("name", "") or ""
+            url = result.get("url", "") or ""
+
+            # 合并标题和 URL 进行检查
+            combined_text = f"{title} {url}".lower()
+
+            # 检查标题是否包含媒体标题的关键字（移除空格后匹配）
+            title_keywords = mediainfo.title.lower().replace(" ", "")
+            if title_keywords not in combined_text.replace(" ", ""):
+                logger.debug(f"PanSou 结果标题不匹配: {title} (期望: {mediainfo.title})，跳过")
+                continue
+
+            # 电影必须检查年份
+            if media_type == MediaType.MOVIE and mediainfo.year:
+                year_str = str(mediainfo.year)
+                if year_str not in combined_text:
+                    logger.debug(f"PanSou 电影结果年份不匹配: {title} (期望年份: {year_str})，跳过")
+                    continue
+
+            # 电视剧必须检查季号
+            if media_type == MediaType.TV and season:
+                season_patterns = [
+                    f"s{season}",
+                    f"s{season:02d}",
+                    f"第{season}季",
+                    f"第{season}辑",
+                    f"{season}季",
+                ]
+                if not any(p in combined_text for p in season_patterns):
+                    logger.debug(f"PanSou 电视剧结果季号不匹配: {title} (期望: S{season})，跳过")
+                    continue
+
+            filtered.append(result)
+            logger.debug(f"PanSou 结果通过过滤: {title}")
+
+        if len(filtered) < len(results):
+            logger.info(f"PanSou 搜索过滤: {len(filtered)}/{len(results)} 条结果通过标题/年份/季号校验")
+
+        return filtered
+
+
 
     def _search_nullbr(
         self,
@@ -246,7 +308,12 @@ class SearchHandler:
             results = self._pansou_search(keyword)
             if results:
                 logger.info(f"PanSou 关键词 '{keyword}' 搜索到 {len(results)} 个结果")
-                return results
+                # 添加标题+年份过滤
+                filtered = self._filter_pansou_results_by_title(
+                    results, mediainfo, MediaType.MOVIE
+                )
+                if filtered:
+                    return filtered
             else:
                 logger.info(f"PanSou 关键词 '{keyword}' 无结果，尝试下一个降级关键词")
 
@@ -280,7 +347,12 @@ class SearchHandler:
             results = self._pansou_search(keyword)
             if results:
                 logger.info(f"PanSou 关键词 '{keyword}' 搜索到 {len(results)} 个结果")
-                return results
+                # 添加标题+年份+季号过滤
+                filtered = self._filter_pansou_results_by_title(
+                    results, mediainfo, MediaType.TV, season
+                )
+                if filtered:
+                    return filtered
             else:
                 logger.info(f"PanSou 关键词 '{keyword}' 无结果，尝试下一个降级关键词")
 


### PR DESCRIPTION
## 修复内容

### 问题描述
PanSou 搜索返回结果没有做标题/年份/季号校验，导致模糊搜索时可能转存到预告片、花絮等不相关内容。

### 解决方案
- 新增 `_filter_pansou_results_by_title` 方法
- 电影搜索结果需匹配：标题 + 年份
- 电视剧搜索结果需匹配：标题 + 季号

### 修改文件
- `plugins.v2/p115strgmsub/handlers/search.py`

### 日志效果
过滤后会在日志中显示：
```
PanSou 搜索过滤: 2/15 条结果通过标题/年份/季号校验
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved movie search filtering to better match title and year, reducing false positives.
  * Enhanced TV search filtering to match title and season patterns (multiple season formats), improving result accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->